### PR TITLE
Use Q_UNREACHABLE when it's correct for better erorr handling readability

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -4,7 +4,7 @@
 #include <math.h>
 
 #include <QtWidgets/QtWidgets>
-#include <qcompilerdetection.h>
+#include <QtGlobal>
 
 #include "Node.hpp"
 #include "FlowScene.hpp"


### PR DESCRIPTION
`Q_UNREACHABLE` is pretty much just an assert(false), so the code will fail with a good error if pc gets here.